### PR TITLE
fix(zyrophr theme): fix border radius of messages

### DIFF
--- a/src/themes/Zyrophr/Zyrophr.scss
+++ b/src/themes/Zyrophr/Zyrophr.scss
@@ -50,7 +50,7 @@
     background: rgba(white, 0.16);
     color: white;
     font-size: 14px;
-    border-radius: 16px;
+    border-radius: 0 0 16px 16px;
     line-height: 1.4;
     text-align: right;
     font-weight: 700;


### PR DESCRIPTION
Before
![CleanShot 2022-08-31 at 18 39 57@2x](https://user-images.githubusercontent.com/8557554/187732909-1e03dcb8-0f50-46cd-a2d2-dbc094f47b97.png)

After
![CleanShot 2022-08-31 at 18 43 52@2x](https://user-images.githubusercontent.com/8557554/187733653-5bdee4d3-0927-44e8-a121-80264a000e0b.png)